### PR TITLE
feat: Add deprecation warning on buggy pgtui types

### DIFF
--- a/src/lib/file-generators/generated/[schema_name]/[TableName].ts
+++ b/src/lib/file-generators/generated/[schema_name]/[TableName].ts
@@ -87,7 +87,7 @@ export const createResultingTypeFile = (
       type: `ReproducePgtuiBugs<${pascal_table_name}>`,
       docs: [
         {
-          description: `@deprecated Reproduces type bugs from the legacy \`pgtui\` library and should not be used in new code.\n\nSpecifically:\n- Fields ending in \`_id\` are incorrectly typed as \`string\`, regardless of their actual database type.\n- \`jsonb\` fields are typed as \`any\` instead of a more specific type.`,
+          description: `@deprecated Reproduces type bugs from the legacy \`pgtui\` library and should not be used in new code.\n\nSpecifically:\n- Columns ending in \`_id\` are incorrectly typed as \`string\`, regardless of their actual database type.\n- \`jsonb\` columns are typed as \`any\` instead of a more specific type.`,
         },
       ],
     })

--- a/src/lib/file-generators/generated/[schema_name]/[TableName].ts
+++ b/src/lib/file-generators/generated/[schema_name]/[TableName].ts
@@ -85,6 +85,11 @@ export const createResultingTypeFile = (
       isExported: true,
       name: `${pascal_table_name}WithPgtuiBugs`,
       type: `ReproducePgtuiBugs<${pascal_table_name}>`,
+      docs: [
+        {
+          description: `@deprecated Reproduces type bugs from the legacy \`pgtui\` library and should not be used in new code.\n\nSpecifically:\n- Fields ending in \`_id\` are incorrectly typed as \`string\`, regardless of their actual database type.\n- \`jsonb\` fields are typed as \`any\` instead of a more specific type.`,
+        },
+      ],
     })
   }
 


### PR DESCRIPTION
Following a discussion with @mxsdev 

Resulting type looks like this

```typescript
/**
 * @deprecated Reproduces type bugs from the legacy `pgtui` library and should not be used in new code.
 *
 * Specifically:
 * - Columns ending in `_id` are incorrectly typed as `string`, regardless of their actual database type.
 * - `jsonb` columns are typed as `any` instead of a more specific type.
 */
export type DeviceWithPgtuiBugs = ReproducePgtuiBugs<Device>
```