### PR TITLE
feat: Add option to add generic provider types

### DIFF
--- a/src/lib/file-generators/custom/[schema_name]/[TableName]CustomTypes.ts
+++ b/src/lib/file-generators/custom/[schema_name]/[TableName]CustomTypes.ts
@@ -34,10 +34,33 @@ export const createCustomTypesFile = (
       moduleSpecifier: `../../generated/${schema.name}/${pascal_table_name}QueryTypes`,
       isTypeOnly: true,
     },
+  ]
+
+  if (table.use_generic_provider) {
+    statements.push({
+      kind: StructureKind.ImportDeclaration,
+      moduleSpecifier: 'lib/spi/provider-model-types',
+      namedImports: ['ProviderTypes'],
+      isTypeOnly: true,
+    })
+  }
+
+  statements.push(
     (writer) => writer.blankLine(),
     {
       kind: StructureKind.TypeAlias,
       name: `${pascal_table_name}CustomTypes`,
+      ...(table.use_generic_provider
+        ? {
+            typeParameters: [
+              {
+                name: 'T',
+                constraint: 'ProviderTypes',
+                default: 'ProviderTypes',
+              },
+            ],
+          }
+        : {}),
       type: `CreateCustomTypes<Selectable${pascal_table_name}, {}>`,
       isExported: true,
     },
@@ -47,7 +70,7 @@ export const createCustomTypesFile = (
       isExportEquals: false,
       expression: `${pascal_table_name}CustomTypes`,
     },
-  ]
+  )
 
   return project.createSourceFile(
     `${output_dir}/custom/${schema.name}/${pascal_table_name}CustomTypes.ts`,

--- a/src/lib/file-generators/generated/[schema_name]/[TableName].ts
+++ b/src/lib/file-generators/generated/[schema_name]/[TableName].ts
@@ -57,6 +57,14 @@ export const createResultingTypeFile = (
         isTypeOnly: true,
       },
     )
+    if (table.use_generic_provider) {
+      statements.push({
+        kind: StructureKind.ImportDeclaration,
+        moduleSpecifier: 'lib/spi/provider-model-types',
+        namedImports: ['ProviderTypes'],
+        isTypeOnly: true,
+      })
+    }
   }
 
   statements.push(
@@ -65,16 +73,38 @@ export const createResultingTypeFile = (
       kind: StructureKind.TypeAlias,
       isExported: true,
       name: pascal_table_name,
+      ...(table.use_generic_provider
+        ? {
+            typeParameters: [
+              {
+                name: 'T',
+                constraint: 'ProviderTypes',
+                default: 'ProviderTypes',
+              },
+            ],
+          }
+        : {}),
       type: table.is_customizable
-        ? `CustomizeDbType<Selectable${pascal_table_name}, ${pascal_table_name}CustomTypes>`
+        ? `CustomizeDbType<Selectable${pascal_table_name}, ${pascal_table_name}CustomTypes${table.use_generic_provider ? '<T>' : ''}>`
         : `Selectable${pascal_table_name}`,
     },
     {
       kind: StructureKind.TypeAlias,
       isExported: true,
       name: `${pascal_table_name}Initializer`,
+      ...(table.use_generic_provider
+        ? {
+            typeParameters: [
+              {
+                name: 'T',
+                constraint: 'ProviderTypes',
+                default: 'ProviderTypes',
+              },
+            ],
+          }
+        : {}),
       type: table.is_customizable
-        ? `CustomizeDbTypeInitializer<Insertable${pascal_table_name}, ${pascal_table_name}CustomTypes>`
+        ? `CustomizeDbTypeInitializer<Insertable${pascal_table_name}, ${pascal_table_name}CustomTypes${table.use_generic_provider ? '<T>' : ''}>`
         : `Insertable${pascal_table_name}`,
     },
   )
@@ -84,7 +114,18 @@ export const createResultingTypeFile = (
       kind: StructureKind.TypeAlias,
       isExported: true,
       name: `${pascal_table_name}WithPgtuiBugs`,
-      type: `ReproducePgtuiBugs<${pascal_table_name}>`,
+      ...(table.use_generic_provider
+        ? {
+            typeParameters: [
+              {
+                name: 'T',
+                constraint: 'ProviderTypes',
+                default: 'ProviderTypes',
+              },
+            ],
+          }
+        : {}),
+      type: `ReproducePgtuiBugs<${pascal_table_name}${table.use_generic_provider ? '<T>' : ''}>`,
       docs: [
         {
           description: `@deprecated Reproduces type bugs from the legacy \`pgtui\` library and should not be used in new code.\n\nSpecifically:\n- Columns ending in \`_id\` are incorrectly typed as \`string\`, regardless of their actual database type.\n- \`jsonb\` columns are typed as \`any\` instead of a more specific type.`,
@@ -95,7 +136,18 @@ export const createResultingTypeFile = (
       kind: StructureKind.TypeAlias,
       isExported: true,
       name: `${pascal_table_name}InitializerWithPgtuiBugs`,
-      type: `ReproducePgtuiBugs<${pascal_table_name}Initializer>`,
+      ...(table.use_generic_provider
+        ? {
+            typeParameters: [
+              {
+                name: 'T',
+                constraint: 'ProviderTypes',
+                default: 'ProviderTypes',
+              },
+            ],
+          }
+        : {}),
+      type: `ReproducePgtuiBugs<${pascal_table_name}Initializer${table.use_generic_provider ? '<T>' : ''}>`,
       docs: [
         {
           description: `@deprecated Reproduces type bugs from the legacy \`pgtui\` library and should not be used in new code.\n\nSpecifically:\n- Columns ending in \`_id\` are incorrectly typed as \`string\`, regardless of their actual database type.\n- \`jsonb\` columns are typed as \`any\` instead of a more specific type.`,

--- a/src/lib/read-database-tree.ts
+++ b/src/lib/read-database-tree.ts
@@ -58,6 +58,7 @@ export const readDatabaseTree = (config: Config): DatabaseTree => {
         is_customizable,
         is_affected_by_pgtui_bugs,
         uses_zapatos_column_type: false,
+        use_generic_provider: false,
       }
 
       table.selectable_columns = getColumns(
@@ -70,6 +71,12 @@ export const readDatabaseTree = (config: Config): DatabaseTree => {
         table,
         zapatos_custom_types,
       )
+      if (config.is_generic_provider_enabled === true) {
+        table.use_generic_provider = Object.prototype.hasOwnProperty.call(
+          table.selectable_columns,
+          'provider_state',
+        )
+      }
 
       tables[table_name] = table
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface Config {
   generate_knex_types?: boolean
   main_schema?: string
   file_header?: string
+  is_generic_provider_enabled?: boolean
 }
 
 export interface DatabaseTree {
@@ -24,6 +25,7 @@ export interface Table {
   is_customizable: boolean
   is_affected_by_pgtui_bugs: boolean
   uses_zapatos_column_type: boolean
+  use_generic_provider: boolean
 }
 
 export interface Column {


### PR DESCRIPTION
## Context
This is very ad-hoc but if the `is_generic_provider_enabled` then tables containing a `provider_state` column will be given a generic provider to work with (imported externally).